### PR TITLE
(feature) renamed week to summarize and modified prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ A Go CLI to capture daily summaries and generate weekly summaries, grouped by pr
 - `reporter week` aggregate a given week (or current week) and ask Ollama to summarize
 - SQLite storage via GORM (DB file: ~/.config/reporter/data.db)
 - Configurable Ollama host and model
+
+## Installation
+TODO
+
+## Connect Ollama
+TODO
+
+## Upcoming features
+- [ ] Ability to connect to ChatGPT API

--- a/internal/cmd/summarize.go
+++ b/internal/cmd/summarize.go
@@ -20,9 +20,9 @@ var (
 )
 
 var weekCmd = &cobra.Command{
-	Use:   "week",
+	Use:   "summarize",
 	Short: "Summarize a week's entries with Ollama",
-	Long:  "Collect summaries in a week range and generate an LLM-powered recap using a local Ollama server.",
+	Long:  "Collect summaries in a week range and generate an LLM-powered recap using a local Ollama server. Default's to current week.",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		var start, end time.Time
 		var err error

--- a/internal/summarize/prompt.go
+++ b/internal/summarize/prompt.go
@@ -14,11 +14,11 @@ func WeeklyPrompt(entries []model.Summary, start, end time.Time) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "You are an assistant helping write a concise weekly work recap for a software engineer.\n")
 	fmt.Fprintf(&b, "Summarize the following daily notes from %s to %s.\n", start.Format(time.DateOnly), end.Format(time.DateOnly))
-	fmt.Fprintf(&b, "Produce a readable summary with:\n- Highlights\n- Completed work\n- In-progress / blockers\n- Notable metrics or PRs\n- Next week focus\n\n")
+	fmt.Fprintf(&b, "Produce a readable summary with:\n- Highlights\n- Completed work\n- In-progress / blockers\n- Notable metrics or PRs\n\n")
 	for _, e := range entries {
 		fmt.Fprintf(&b, "## %s\n", e.Date.Format("Mon 2006-01-02"))
 		fmt.Fprintf(&b, "%s\n\n", strings.TrimSpace(e.Text))
 	}
-	fmt.Fprintf(&b, "Keep it under 250 words if possible. Use bullet points when appropriate.")
+	fmt.Fprintf(&b, "Keep it under 250 words if possible. Use bullet points when appropriate. Try to not make things up and stick to the information given.")
 	return b.String()
 }


### PR DESCRIPTION
- Renamed "week" command to "summarize". This sounds more fluent in my eyes.
- Slightly tweaked the prompt to encourage it to not invent things. 
- Added to the README.md file with things I should add in the future.